### PR TITLE
Replacing the hardcoded limit for valid email date

### DIFF
--- a/src/java/edu/stanford/muse/email/EmailFetcherThread.java
+++ b/src/java/edu/stanford/muse/email/EmailFetcherThread.java
@@ -303,7 +303,8 @@ public class EmailFetcherThread implements Runnable, Serializable {
             Calendar c = new GregorianCalendar();
             c.setTime(d);
             int yy = c.get(Calendar.YEAR);
-            if (yy < 1960 || yy > 2020) {
+            int currentYear = Calendar.getInstance().get(Calendar.YEAR);
+            if (yy < 1960 || yy > currentYear) {
                 dataErrors.add("Probably bad date: " + Util.formatDate(c) + " message: " + EmailUtils.formatMessageHeader(m));
                 probablyWrongDate = true;
 


### PR DESCRIPTION
 of 2020 by the current year from the calendar. This solves issue #402.