### PR TITLE
Setting sortBy in browseMessages.jspf to 'recent' initially.

### DIFF
--- a/WebContent/browseMessages.jspf
+++ b/WebContent/browseMessages.jspf
@@ -361,7 +361,10 @@ a jquery ($) object that is overwritten when header.jsp is included! -->
         //we need to pass that ordered set to getHTML* method below. This fixed the issue.
         Pair<DataSet, JSONArray> pair = null;
         try {
-
+			if (sortBy == null)
+			{
+					sortBy = "recent";
+			}
             // note: we currently do not support clustering for "recent" type, only for the chronological type.
             // might be easy to fix if needed in the future.
             if ("recent".equals(sortBy) || "relevance".equals(sortBy) || "chronological".equals(sortBy))


### PR DESCRIPTION
Setting sortBy in browseMessages.jspf to a default value of ‘recent’ initially. This avoids sortBy being null and execution running through a path that is not in use anymore.

I am not sure whether that makes any practical difference but it seems to be safer as it says
_this path should not be used as it sorts the docs in some order
(old code meant to handle clustered docs, so that tab can jump from cluster to cluster. not used now)_