### PR TITLE
The method getDupMessageInfo() in Archive.java used to return a new M…

### DIFF
--- a/src/java/edu/stanford/muse/index/Archive.java
+++ b/src/java/edu/stanford/muse/index/Archive.java
@@ -115,7 +115,9 @@ public class Archive implements Serializable {
 
     public Multimap<Document, Tuple2<String,String>> getDupMessageInfo() {
         if(dupMessageInfo==null)
-            return LinkedHashMultimap.create();
+        {
+            dupMessageInfo = LinkedHashMultimap.create();
+        }
         return dupMessageInfo;
     }
 


### PR DESCRIPTION
…ultiMap in

case dupMessageInfo is null without assigning it to dupMessageInfo.
This has been fixed and solves issue #408.