### PR TITLE
Fix for issue #414 (Emails in Mbox format with to or from fields cont…

### DIFF
--- a/src/java/edu/stanford/muse/AddressBookManager/Contact.java
+++ b/src/java/edu/stanford/muse/AddressBookManager/Contact.java
@@ -413,13 +413,19 @@ public class Contact extends UnionFindObject {
 		boolean isFirst = true;
 		//int state  = 0;
 		//0=name_reading,1= email_reading,2=state_reading
+		boolean foundEmail = false;
 		while(inp!=null){
 			if(inp.trim().startsWith(AddressBook.CONTACT_START_PREFIX)) {
+				if (!foundEmail)
+				{
+					tmp.getEmails().add(Util.escapeHTML(tmp.bestName));
+				}
 				//reset to the marked position
 				in.reset();
 				return tmp;
 			}
 			else if(inp.trim().contains("@")) {
+				foundEmail = true;
 				if(isFirst) {
 					tmp.setBestName(Util.escapeHTML(inp.trim()));
 					isFirst = false;
@@ -436,7 +442,8 @@ public class Contact extends UnionFindObject {
 			in.mark(1000);//here readAheadLimit tells how many characters stream can read
 			//without losing the mark. In this case we assume that one line of contact can not be more than 1000 characters.
 			//which is a realistic assumption.
-				inp = in.readLine();
+			inp = in.readLine();
+
 			/*
 			if(inp.trim().compareTo("###Names###")==0){
 				inp = in.readLine();
@@ -461,7 +468,13 @@ public class Contact extends UnionFindObject {
 			}*/
 
 		}
+		
+		if (tmp.getEmails().isEmpty())
+		{
+			tmp.emails.add(tmp.bestName);
+		}
 		//Util.warnIf(true,"Control should not reach here while reading a contact object", JSPHelper.log);
+		//(But the last contact doesn't end with --, so we end up here.)
 		return tmp;
 	}
 


### PR DESCRIPTION
…aining only names but no email addresses appear in the list of correspondents after importing an Mbox file but
are missing after restarting ePADD).

When ePADD is restarted after importing an Mbox file, the Contact objects (/epadd/src/java/edu/stanford/muse/AddressBookManager/Contact.java) are deserialised from the disk.
In readObjectFromStream email addresses for a contact are added to its list of emails by looking at lines containing an ‘@’ (a contact can have more than one email address). If such a line is not found, then the list of emails will be empty.
The fix adds the first name found for the contact to the list of emails if no ‘@’ has been found. The first found name and (the only) email are then identical.
