### PR TITLE
Forces JSP to handle UTF-8

### DIFF
--- a/WebContent/WEB-INF/web.xml
+++ b/WebContent/WEB-INF/web.xml
@@ -13,6 +13,9 @@
 		<welcome-file>default.htm</welcome-file>
 		<welcome-file>default.jsp</welcome-file>
 	</welcome-file-list>
+	
+	<!-- works only with Tomcat 9.0 with 4.0 servlet spec -->
+        <request-character-encoding>UTF-8</request-character-encoding>
 
 	<servlet>
 		<servlet-name>jsp</servlet-name>
@@ -48,6 +51,18 @@
 	    <listener-class>edu.stanford.muse.webapp.SessionListener</listener-class>
 	</listener>
 
+	<!--
+	Declare a character encoding to handle form response in UTF-8.
+	The Filter comes only with the Tomcat server...
+	-->	
+	<filter>
+		<filter-name>SetCharacterEncoding</filter-name>
+		<filter-class>org.apache.catalina.filters.SetCharacterEncodingFilter</filter-class>
+		<init-param>
+			<param-name>encoding</param-name>
+			<param-value>UTF-8</param-value>
+		</init-param>
+	</filter>
 	<filter>
 	    <filter-name>LoggingFilter</filter-name>
 	    <filter-class>
@@ -59,15 +74,30 @@
 	    </init-param>
 	</filter>
 
+	<!--
+	THIS FILTER MAPPING MUST BE THE FIRST ONE, 
+	otherwise we end up with ruined chars in the input from the GUI
+	See the "Note" in the Tomcat character encoding guide:  http://wiki.apache.org/tomcat/FAQ/CharacterEncoding
+	-->
 	<filter-mapping>
+		<filter-name>SetCharacterEncoding</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
+ 	<filter-mapping>
 	    <filter-name>LoggingFilter</filter-name>
 	    <url-pattern>/*</url-pattern>
 	</filter-mapping>
 
 	<!--  treat jspf files as jsp so that they get translated. See http://www.coderanch.com/t/171516/java-Web-Component-SCWCD/certification/jspf-file-behaving-jsp-file-->
+	<!-- force every JSP or JSPF page to be UTF-8 encoded -->
 	<jsp-config>
 		<jsp-property-group>
 			<url-pattern>*.jspf</url-pattern>
+			<page-encoding>UTF-8</page-encoding>
+		</jsp-property-group>
+		<jsp-property-group>
+			<url-pattern>*.jsp</url-pattern>
+			<page-encoding>UTF-8</page-encoding>
 		</jsp-property-group>
 	</jsp-config>
 

--- a/WebContent/browse-top.jsp
+++ b/WebContent/browse-top.jsp
@@ -1,3 +1,4 @@
+<%@page pageEncoding="UTF-8"%>
 <%@page contentType="text/html; charset=UTF-8"%>
 <%@page trimDirectiveWhitespaces="true"%>
 <%@page language="java" import="edu.stanford.muse.AddressBookManager.AddressBook"%>
@@ -72,6 +73,7 @@
 	//is present in the request the headers are not rendered properly. Now we set archiveID from the archive object
 	//that was loaded by default from the appraisal directory. This property is then read by header.jspf (if archiveID
 	//not passed from the request) and used for rendering the header properly.
+	request.setCharacterEncoding("UTF-8");
 	if(archive != null && request.getParameter("archiveID")==null)
 		request.setAttribute("archiveID", ArchiveReaderWriter.getArchiveIDForArchive(archive));
 %>

--- a/WebContent/edit-correspondents.jsp
+++ b/WebContent/edit-correspondents.jsp
@@ -1,3 +1,4 @@
+<%@page pageEncoding="UTF-8"%>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <%@page import="java.io.*"%>
 <%@page trimDirectiveWhitespaces="true"%>
@@ -99,7 +100,7 @@
 
 <p>
 <div style="text-align:center">
-<form method="post" action="browse-top">
+<form method="post" accept-charset="utf-8" action="browse-top">
 	<!-- adding a hidden input field to pass archiveID to the server. This is a common pattern used to pass
 	//archiveID in all those forms where POST was used to invoke the server page. -->
 	<input type="hidden" value="<%=archiveID%>" class="form-control" name="archiveID"/>


### PR DESCRIPTION
Forcing the JVM to handle IO in UTF-8, with the `-Dfile.encoding=UTF-8`, is not enough to force the servlet and the JSP pages to handle UTF-8 properly.

Adding the charset encoding in the JSP pageencoding and adding a filter to encode and decode POST request, ensure the character are well matches all along.

The proposed PR works for the standalone jar and the embedded Tomcat 9 server.
I'm unsure the proposed filter will work with the dev environment using the jetty server.

Other forms in the application might need the addition of the `accept-charset` attribute to ensure the navigator accepts UTF-8 inputs or textareas.

Fixes #481